### PR TITLE
correct housebound definition

### DIFF
--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -901,7 +901,7 @@ study = StudyDefinition(
     ),
     moved_into_care_home=patients.with_these_clinical_events(
       codelists.carehome,
-      on_or_after="housebound_date",
+      between=["housebound_date", "covid_vax_disease_3_date - 1 day"],
     ),
   ),
   


### PR DESCRIPTION
This bug fix ensures that we no longer count people as being not housebound if they stopped being housebound at any point in time, _even_ if its after the baseline date.  h/t @evansd